### PR TITLE
Switch to fork for `jit-allocator` fixing win32 linker issue

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,41 +51,30 @@ jobs:
         profile:
           - dev
           - release
-        runner:
-          - ubuntu-latest # x86_64-unknown-linux-gnu
-          - windows-latest # x86_64-pc-windows-msvc
-          - macos-latest # aarch64-apple-darwin
-          - ubuntu-24.04-arm # aarch64-unknown-linux-gnu
-          - macos-13 # x86_64-apple-darwin
+        target:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+          - runner: macos-13
+            target: x86_64-apple-darwin
+          - runner: windows-latest
+            target: i686-pc-windows-msvc
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - runner: macos-latest
+            target: aarch64-apple-darwin
     
     needs: [fmt, check] # don't bother running tests if cargo check/fmt doesn't pass
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.target.runner }}
     steps:
       - uses: actions/checkout@v4
+      - run: rustup target add ${{ matrix.target.target }}
       - name: Full feature set build and test
-        run: cargo test --profile ${{ matrix.profile }} -F full
+        run: cargo test --target ${{ matrix.target.target }} --profile ${{ matrix.profile }} -F full
       - run: cargo clean
       - name: Custom JIT alloc build and test
-        run: cargo test --profile ${{ matrix.profile }} --no-default-features -F custom_jit_alloc
-
-  build_and_test_i686_windows:
-    strategy:
-      fail-fast: false
-      matrix:
-        profile:
-          - dev
-          - release
-    runs-on: windows-latest
-
-    needs: [fmt, check]
-    steps:
-      - uses: actions/checkout@v4
-      - run: rustup target add i686-pc-windows-msvc
-      - name: Full feature set build and test
-        run: cargo test --target i686-pc-windows-msvc --profile ${{ matrix.profile }} -F full
-      - run: cargo clean
-      - name: Custom JIT alloc build and test
-        run: cargo test --target i686-pc-windows-msvc --profile ${{ matrix.profile }} --no-default-features -F custom_jit_alloc
+        run: cargo test --target ${{ matrix.target.target }} --profile ${{ matrix.profile }} --no-default-features -F custom_jit_alloc
   
   all_checks_pass:
     needs:
@@ -93,7 +82,6 @@ jobs:
       - check
       - doc
       - build_and_test
-      - build_and_test_i686_windows
     runs-on: ubuntu-latest
     steps:
     - name: Decide whether the needed jobs succeeded or failed

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -81,10 +81,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup target add i686-pc-windows-msvc
-      # At the moment, bundled_jit_alloc is not supported on i686 windows due to a linker error
-      # in jit-allocator
-      - run: cargo build --target i686-pc-windows-msvc --profile ${{ matrix.profile }} --no-default-features
-      - run: cargo test --target i686-pc-windows-msvc --profile ${{ matrix.profile }} --no-default-features
+      - name: Full feature set build and test
+        run: cargo test --target i686-pc-windows-msvc --profile ${{ matrix.profile }} -F full
+      - run: cargo clean
+      - name: Custom JIT alloc build and test
+        run: cargo test --target i686-pc-windows-msvc --profile ${{ matrix.profile }} --no-default-features -F custom_jit_alloc
   
   all_checks_pass:
     needs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.2.0] - 2025-05-30
+
+### Fixed
+- `bundled_jit_alloc` should now work on `i686-pc-windows-msvc` without linker errors
+
+### Changed
+- Bundled JIT allocator now uses [`jit-allocator2`](https://crates.io/crates/jit-allocator2), a 
+  maintained fork of [`jit-allocator`](https://crates.io/crates/jit-allocator2) which fixes 
+  a linker issue on `i686-pc-windows-msvc`.
+
 ## [v2.1.0] - 2025-05-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ version = "2.1.0"
 dependencies = [
  "clear-cache",
  "closure-ffi-proc-macros",
- "jit-allocator",
+ "jit-allocator2",
  "libc",
  "region",
  "spin",
@@ -83,10 +83,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "jit-allocator"
-version = "0.2.8"
+name = "jit-allocator2"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28cf4ebc39fb6f738ec0d837aa6ad34d5ce3902c275b298fad2d0e9f857fff0"
+checksum = "d47f4f79cbe2ba240bc3d4e9873eb5d78797c6baa983fc5caca222c04b0fee2e"
 dependencies = [
  "cfgenius",
  "errno",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
 
 [[package]]
 name = "closure-ffi"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "clear-cache",
  "closure-ffi-proc-macros",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "closure-ffi-proc-macros"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ test = true
 [features]
 default = [ "bundled_jit_alloc" ]
 no_std = [ "spin" ]
-bundled_jit_alloc = [ "jit-allocator" ]
+bundled_jit_alloc = [ "jit-allocator2" ]
 custom_jit_alloc = []
 unstable = []
 proc_macros = [ "closure-ffi-proc-macros" ]
@@ -36,7 +36,7 @@ full = [ "bundled_jit_alloc", "proc_macros" ]
 
 [dependencies]
 closure-ffi-proc-macros = { path = "proc_macros", version = "2.1.0", optional = true }
-jit-allocator = {version = "0.2.8", optional = true }
+jit-allocator2 = {version = "0.2.9", optional = true }
 spin = { version = "0.10", optional = true }
 
 [target.'cfg(all(target_arch = "arm", target_os = "linux"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/tremwil/closure-ffi"
 
 [package]
 name = "closure-ffi"
-version = "2.1.0"
+version = "2.2.0"
 description = "FFI utility for creating bare function pointers that invoke a closure"
 edition.workspace = true
 authors.workspace = true
@@ -35,7 +35,7 @@ proc_macros = [ "closure-ffi-proc-macros" ]
 full = [ "bundled_jit_alloc", "proc_macros" ]
 
 [dependencies]
-closure-ffi-proc-macros = { path = "proc_macros", version = "2.1.0", optional = true }
+closure-ffi-proc-macros = { path = "proc_macros", version = "2.2.0", optional = true }
 jit-allocator2 = {version = "0.2.9", optional = true }
 spin = { version = "0.10", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ scenarios, e.g. function hooking for game modding/hacking.
 The crate comes with the following feature flags:
 - `no_std`: Makes the crate compatible with `#![no_std]`. A dependency on `alloc` and `spin` is
   still required.
-- `bundled_jit_alloc`: Provides a global JIT allocator through the [`jit-allocator`](https://crates.io/crates/jit-allocator)
+- `bundled_jit_alloc`: Provides a global JIT allocator through the [`jit-allocator2`](https://crates.io/crates/jit-allocator2)
   crate. This is enabled by default.
 - `custom_jit_alloc`: Allows providing a global JIT allocator through the `global_jit_alloc!` macro.
   **This is incompatible with `bundled_jit_alloc`**.

--- a/proc_macros/Cargo.toml
+++ b/proc_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "closure-ffi-proc-macros"
-version = "2.1.0"
+version = "2.2.0"
 description = "Proc macros used and exported by the closure-ffi crate"
 edition.workspace = true
 authors.workspace = true

--- a/src/jit_alloc.rs
+++ b/src/jit_alloc.rs
@@ -124,7 +124,7 @@ impl<J: JitAlloc, R: spin::RelaxStrategy> JitAlloc for spin::lazy::Lazy<J, fn() 
 /// The default, global JIT allocator.
 ///
 /// When the `bundled_jit_alloc` feature is enabled, this is currently implemented as a ZST
-/// deffering to a static [`jit_allocator::JitAllocator`] behind a [`std::sync::Mutex`] (or a
+/// deffering to a static [`jit_allocator2::JitAllocator`] behind a [`std::sync::Mutex`] (or a
 /// [`spin::Mutex`](https://docs.rs/spin/0.9/spin/type.Mutex.html) under `no_std`).
 ///
 /// When the `custom_jit_alloc` feature is enabled, defers to a [`JitAlloc`] implementation
@@ -134,15 +134,15 @@ pub struct GlobalJitAlloc;
 
 #[cfg(feature = "bundled_jit_alloc")]
 mod bundled_jit_alloc {
-    use jit_allocator::JitAllocator;
+    use jit_allocator2::JitAllocator;
 
     use super::*;
 
     #[inline(always)]
-    fn convert_access(access: ProtectJitAccess) -> jit_allocator::ProtectJitAccess {
+    fn convert_access(access: ProtectJitAccess) -> jit_allocator2::ProtectJitAccess {
         match access {
-            ProtectJitAccess::ReadExecute => jit_allocator::ProtectJitAccess::ReadExecute,
-            ProtectJitAccess::ReadWrite => jit_allocator::ProtectJitAccess::ReadWrite,
+            ProtectJitAccess::ReadExecute => jit_allocator2::ProtectJitAccess::ReadExecute,
+            ProtectJitAccess::ReadWrite => jit_allocator2::ProtectJitAccess::ReadWrite,
         }
     }
 
@@ -159,7 +159,7 @@ mod bundled_jit_alloc {
             return;
         }
         #[allow(unreachable_code)]
-        jit_allocator::flush_instruction_cache(rx_ptr, size);
+        jit_allocator2::flush_instruction_cache(rx_ptr, size);
     }
 
     impl JitAlloc for core::cell::RefCell<JitAllocator> {
@@ -183,7 +183,7 @@ mod bundled_jit_alloc {
             _size: usize,
             access: ProtectJitAccess,
         ) {
-            jit_allocator::protect_jit_memory(convert_access(access));
+            jit_allocator2::protect_jit_memory(convert_access(access));
         }
     }
 
@@ -209,7 +209,7 @@ mod bundled_jit_alloc {
             _size: usize,
             access: ProtectJitAccess,
         ) {
-            jit_allocator::protect_jit_memory(convert_access(access));
+            jit_allocator2::protect_jit_memory(convert_access(access));
         }
     }
 
@@ -235,7 +235,7 @@ mod bundled_jit_alloc {
             _size: usize,
             access: ProtectJitAccess,
         ) {
-            jit_allocator::protect_jit_memory(convert_access(access));
+            jit_allocator2::protect_jit_memory(convert_access(access));
         }
     }
 
@@ -279,7 +279,7 @@ mod bundled_jit_alloc {
             _size: usize,
             access: ProtectJitAccess,
         ) {
-            jit_allocator::protect_jit_memory(convert_access(access));
+            jit_allocator2::protect_jit_memory(convert_access(access));
         }
     }
 
@@ -287,7 +287,7 @@ mod bundled_jit_alloc {
     pub(super) mod thread_jit_alloc {
         use core::{cell::UnsafeCell, marker::PhantomData};
 
-        use jit_allocator::JitAllocator;
+        use jit_allocator2::JitAllocator;
 
         #[allow(unused_imports)]
         use super::*;
@@ -328,7 +328,7 @@ mod bundled_jit_alloc {
                 _size: usize,
                 access: ProtectJitAccess,
             ) {
-                jit_allocator::protect_jit_memory(convert_access(access));
+                jit_allocator2::protect_jit_memory(convert_access(access));
             }
         }
     }


### PR DESCRIPTION
Currently, the `bundled_jit_alloc` feature is not supported on `i686-pc-windows-msvc` due to a linker error caused by an incorrect extern function calling convention in the `jit_allocator` crate. This switches to a fork where the bug is fixed.