### PR TITLE
Feat: untyped BareFn variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v3.0.0] - 2025-06-20
+
+### Breaking Changes
+- `ToBoxedUnsize` is now an unsafe trait.
+- `Send` and `Sync` impl bounds on `BareFn` are now stricter to catch more unsafety.
+
+### Added
+- `UntypedBareFn*` types that erase the bare function type entirely. Can be used to store
+  `BareFn*` wrappers of different types in a data structure.
+
+### Changed
+- Change thunk assembly magic numbers/sentinel values to sequences that are guaranteed to not be emitted by the compiler.
+  Thanks to @Dasaav-dsv for the help.
+
 ## [v2.4.0] - 2025-06-08
 
 ### Added

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -7,11 +7,11 @@ use crate::jit_alloc::{JitAlloc, JitAllocError, ProtectJitAccess};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[doc(hidden)]
-pub mod magic {
+pub mod consts {
     // Define it as 2 u64s to use with inline asm const directive
-    pub(super) type Type = [u64; 2];
-    pub const CLOSURE_ADDR_MAGIC: Type = {
-        // lock (x14) push rax, which is invalid no matter the offset into the sequence
+    pub(super) type Magic = [u64; 2];
+    pub const CLOSURE_ADDR_MAGIC: Magic = {
+        // lock (x14) push rax/eax, which is invalid no matter the offset into the sequence
         // Credit: https://github.com/Dasaav-dsv/
         #[repr(C)]
         struct LockPushRax([u8; 14], [u8; 2]);
@@ -19,34 +19,47 @@ pub mod magic {
         unsafe { core::mem::transmute_copy(&LockPushRax([0xF0; 14], [0xFF, 0xF0])) }
     };
 
-    pub(super) const THUNK_EXTRA_RETURN: usize = size_of::<Type>();
+    #[cfg(target_arch = "x86")]
+    mod inner {
+        pub const THUNK_EXTRA_SIZE: isize = -4;
+        pub const CLOSURE_ADDR_OFFSET: isize = -15;
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    mod inner {
+        pub const THUNK_RETURN_OFFSET: usize = size_of::<super::Magic>();
+        pub const THUNK_EXTRA_SIZE: isize = THUNK_RETURN_OFFSET as isize;
+        pub const CLOSURE_ADDR_OFFSET: isize = 0;
+    }
+
+    pub(super) use inner::*;
 }
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 #[doc(hidden)]
-pub mod magic {
-    pub(super) type Type = usize;
+pub mod consts {
+    pub(super) type Magic = usize;
 
     // UDF 0xDEAD repeated twice
     #[cfg(target_arch = "aarch64")]
-    pub const CLOSURE_ADDR_MAGIC: Type = 0x0000DEAD0000DEAD_u64 as usize;
+    pub const CLOSURE_ADDR_MAGIC: Magic = 0x0000DEAD0000DEAD_u64 as usize;
 
     // UDF 0xDEAD
     #[cfg(all(target_arch = "arm", not(thumb_mode)))]
-    pub const CLOSURE_ADDR_MAGIC: Type = 0xE7FDEAFD;
+    pub const CLOSURE_ADDR_MAGIC: Magic = 0xE7FDEAFD;
 
     // UDF #42 repeated twice
     #[cfg(all(target_arch = "arm", thumb_mode))]
-    pub const CLOSURE_ADDR_MAGIC: Type = 0xDE2ADE2A;
+    pub const CLOSURE_ADDR_MAGIC: Magic = 0xDE2ADE2A;
 
-    pub(super) const THUNK_EXTRA_RETURN: usize = super::THUNK_EXTRA_SIZE;
+    pub(super) const THUNK_RETURN_OFFSET: usize = 2 * size_of::<usize>();
+    pub(super) const THUNK_EXTRA_SIZE: isize = THUNK_RETURN_OFFSET as isize;
+    pub(super) const CLOSURE_ADDR_OFFSET: isize = 0;
 }
-
-const THUNK_EXTRA_SIZE: usize = 2 * size_of::<usize>();
 
 // We perform aligned reads at the pointer size, so make sure the align is sufficient
 const _ASSERT_MAGIC_TYPE_SUFFICIENT_ALIGN: () =
-    assert!(align_of::<magic::Type>() >= align_of::<usize>());
+    assert!(align_of::<consts::Magic>() >= align_of::<usize>());
 
 // We have to expose the thunk asm macros to allow the hrtb_cc proc macro to generate more complex
 // thunk templates
@@ -64,8 +77,8 @@ macro_rules! _thunk_asm {
             "2:",
             ".8byte {cl_magic_0}",
             ".8byte {cl_magic_1}",
-            cl_magic_0 = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC[0] },
-            cl_magic_1 = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC[1] },
+            cl_magic_0 = const { $crate::arch::consts::CLOSURE_ADDR_MAGIC[0] },
+            cl_magic_1 = const { $crate::arch::consts::CLOSURE_ADDR_MAGIC[1] },
             cl_addr = out(reg) $closure_ptr,
             options(nostack)
         );
@@ -79,15 +92,16 @@ macro_rules! _thunk_asm {
 macro_rules! _thunk_asm {
     ($closure_ptr:ident) => {
         ::core::arch::asm!(
-            "mov $1f, {cl_addr}",
-            "mov $1f+4, {jmp_addr}",
+            ".balign 8",
+            "movl $0xC0DEC0DE, {cl_addr}",
+            "movl $1f, {jmp_addr}",
             "jmp *{jmp_addr}",
-            ".balign 8, 0xCC",
-            "1:",
+            ".4byte 0xCCCCCCCC",
             ".8byte {cl_magic_0}",
             ".8byte {cl_magic_1}",
-            cl_magic_0 = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC[0] },
-            cl_magic_1 = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC[1] },
+            "1:",
+            cl_magic_0 = const { $crate::arch::consts::CLOSURE_ADDR_MAGIC[0] },
+            cl_magic_1 = const { $crate::arch::consts::CLOSURE_ADDR_MAGIC[1] },
             cl_addr = out(reg) $closure_ptr,
             jmp_addr = out(reg) _,
             options(nostack, att_syntax)
@@ -110,7 +124,7 @@ macro_rules! _thunk_asm {
             ".8byte {cl_magic}",
             "2:",
             ".8byte 0",
-            cl_magic = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC },
+            cl_magic = const { $crate::arch::consts::CLOSURE_ADDR_MAGIC },
             cl_addr = out(reg) $closure_ptr,
             jmp_addr = out(reg) _,
             options(nostack)
@@ -119,7 +133,7 @@ macro_rules! _thunk_asm {
 }
 
 /// Internal. Do not use.
-#[cfg(all(target_arch = "arm", not(thumb_mode)))]
+#[cfg(target_arch = "arm")]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! _thunk_asm {
@@ -133,29 +147,7 @@ macro_rules! _thunk_asm {
             ".4byte {cl_magic}",
             "2:",
             ".4byte 0",
-            cl_magic = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC },
-            cl_addr = out(reg) $closure_ptr,
-            jmp_addr = out(reg) _,
-            options(nostack)
-        );
-    };
-}
-/// Internal. Do not use.
-#[cfg(all(target_arch = "arm", thumb_mode))]
-#[doc(hidden)]
-#[macro_export]
-macro_rules! _thunk_asm {
-    ($closure_ptr:ident) => {
-        ::core::arch::asm!(
-            "ldr {cl_addr}, 1f",
-            "ldr {jmp_addr}, 2f",
-            "bx {jmp_addr}",
-            ".align 2",
-            "1:",
-            ".4byte {cl_magic}",
-            "2:",
-            ".4byte 0",
-            cl_magic = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC },
+            cl_magic = const { $crate::arch::consts::CLOSURE_ADDR_MAGIC },
             cl_addr = out(reg) $closure_ptr,
             jmp_addr = out(reg) _,
             options(nostack)
@@ -182,7 +174,7 @@ pub(crate) unsafe fn create_thunk<J: JitAlloc>(
     closure_ptr: *const (),
     jit: &J,
 ) -> Result<ThunkInfo, JitAllocError> {
-    const MAGIC_ALIGN: usize = align_of::<magic::Type>();
+    const MAGIC_ALIGN: usize = align_of::<consts::Magic>();
 
     // When in thumb mode, the thunk pointer will have the lower bit set to 1. Clear it
     #[cfg(thumb_mode)]
@@ -191,10 +183,10 @@ pub(crate) unsafe fn create_thunk<J: JitAlloc>(
     // Align to pointer size and search for the magic number to be replaced by the
     // closure address
     let mut offset = thunk_template.align_offset(MAGIC_ALIGN);
-    while thunk_template.add(offset).cast::<magic::Type>().read() != magic::CLOSURE_ADDR_MAGIC {
+    while thunk_template.add(offset).cast::<consts::Magic>().read() != consts::CLOSURE_ADDR_MAGIC {
         offset += MAGIC_ALIGN;
     }
-    let thunk_size = offset + THUNK_EXTRA_SIZE;
+    let thunk_size = offset.wrapping_add_signed(consts::THUNK_EXTRA_SIZE);
 
     // Skip initial bytes for proper alignment
     let (rx, rw) = jit.alloc(thunk_size + MAGIC_ALIGN - 1)?;
@@ -207,14 +199,20 @@ pub(crate) unsafe fn create_thunk<J: JitAlloc>(
     core::ptr::copy_nonoverlapping(thunk_template, rw, thunk_size);
 
     // Write the closure pointer
-    rw.add(offset).cast::<*const ()>().write(closure_ptr);
+    rw.add(offset.wrapping_add_signed(consts::CLOSURE_ADDR_OFFSET))
+        .cast::<*const ()>()
+        .write_unaligned(closure_ptr);
 
-    // Write the jump back to the compiler-generated thunk
-    let thunk_return = thunk_template.add(offset + magic::THUNK_EXTRA_RETURN);
-    // When in thumb mode, set the lower bit to one so we don't switch to A32 mode
-    #[cfg(thumb_mode)]
-    let thunk_return = thunk_return.map_addr(|a| a | 1);
-    rw.add(offset + size_of::<usize>()).cast::<*const u8>().write(thunk_return);
+    // On x86, we use a PE/ELF relocation to load the return address instead
+    #[cfg(not(target_arch = "x86"))]
+    {
+        // Write the jump back to the compiler-generated thunk
+        let thunk_return = thunk_template.add(offset + consts::THUNK_RETURN_OFFSET);
+        // When in thumb mode, set the lower bit to one so we don't switch to A32 mode
+        #[cfg(thumb_mode)]
+        let thunk_return = thunk_return.map_addr(|a| a | 1);
+        rw.add(offset + size_of::<usize>()).cast::<*const u8>().write(thunk_return);
+    }
 
     jit.protect_jit_memory(thunk_rx, thunk_size, ProtectJitAccess::ReadExecute);
     jit.flush_instruction_cache(thunk_rx, thunk_size);

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -80,8 +80,8 @@ macro_rules! _thunk_asm {
             "jmp *{jmp_addr}",
             ".balign 8, 0xCC",
             "1:",
-            ".8byte cl_magic_0",
-            ".8byte cl_magic_1",
+            ".8byte {cl_magic_0}",
+            ".8byte {cl_magic_1}",
             cl_magic_0 = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC[0] },
             cl_magic_1 = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC[1] },
             cl_addr = out(reg) $closure_ptr,
@@ -106,7 +106,7 @@ macro_rules! _thunk_asm {
             ".8byte {cl_magic}",
             "2:",
             ".8byte 0",
-            cl_magic = const { $crate::arch::CLOSURE_ADDR_MAGIC },
+            cl_magic = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC },
             cl_addr = out(reg) $closure_ptr,
             jmp_addr = out(reg) _,
             options(nostack)
@@ -129,7 +129,7 @@ macro_rules! _thunk_asm {
             ".4byte {cl_magic}",
             "2:",
             ".4byte 0",
-            cl_magic = const { $crate::arch::CLOSURE_ADDR_MAGIC },
+            cl_magic = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC },
             cl_addr = out(reg) $closure_ptr,
             jmp_addr = out(reg) _,
             options(nostack)
@@ -151,7 +151,7 @@ macro_rules! _thunk_asm {
             ".4byte {cl_magic}",
             "2:",
             ".4byte 0",
-            cl_magic = const { $crate::arch::CLOSURE_ADDR_MAGIC },
+            cl_magic = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC },
             cl_addr = out(reg) $closure_ptr,
             jmp_addr = out(reg) _,
             options(nostack)

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -76,7 +76,7 @@ macro_rules! _thunk_asm {
     ($closure_ptr:ident) => {
         ::core::arch::asm!(
             "mov $1f, {cl_addr}",
-            "mov $1f+$4, {jmp_addr}",
+            "mov $1f+4, {jmp_addr}",
             "jmp *{jmp_addr}",
             ".balign 8, 0xCC",
             "1:",

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -7,16 +7,42 @@ use crate::jit_alloc::{JitAlloc, JitAllocError, ProtectJitAccess};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[doc(hidden)]
-pub const CLOSURE_ADDR_MAGIC: usize = 0x0ebe4a8e072bdb2a_u64 as usize;
+pub mod magic {
+    // Define it as 2 u64s to use with inline asm const directive
+    pub(super) type Type = [u64; 2];
+    pub const CLOSURE_ADDR_MAGIC: Type = {
+        // lock (x14) push rax, which is invalid no matter the offset into the sequence
+        // Credit: https://github.com/Dasaav-dsv/
+        #[repr(C)]
+        struct LockPushRax([u8; 14], [u8; 2]);
+        // SAFETY: bit pattern is valid for dest type and sizes match
+        unsafe { core::mem::transmute_copy(&LockPushRax([0xF0; 14], [0xFF, 0xF0])) }
+    };
+}
 
 #[cfg(any(target_arch = "arm", target_arch = "aarch64"))]
 #[doc(hidden)]
-pub const CLOSURE_ADDR_MAGIC: usize = 0x0000DEAD0000DEAD_u64 as usize;
+pub mod magic {
+    pub(super) type Type = usize;
 
-#[cfg(target_arch = "x86")]
-pub const THUNK_EXTRA_SIZE: usize = 4 + 5 + 2; // mov closure, mov return, jmp
-#[cfg(not(target_arch = "x86"))]
-pub const THUNK_EXTRA_SIZE: usize = size_of::<usize>() * 2; // closure addr, return addr
+    // UDF 0xDEAD repeated twice
+    #[cfg(target_arch = "aarch64")]
+    pub const CLOSURE_ADDR_MAGIC: usize = 0x0000DEAD0000DEAD_u64 as usize;
+
+    // UDF 0xDEAD
+    #[cfg(all(target_arch = "arm", not(thumb_mode)))]
+    pub const CLOSURE_ADDR_MAGIC: usize = 0xE7FDEAFD;
+
+    // UDF #42 repeated twice
+    #[cfg(all(target_arch = "arm", thumb_mode))]
+    pub const CLOSURE_ADDR_MAGIC: usize = 0xDE2ADE2A;
+}
+
+// We perform aligned reads at the pointer size, so make sure the align is sufficient
+const _ASSERT_MAGIC_TYPE_SUFFICIENT_ALIGN: () =
+    assert!(align_of::<magic::Type>() >= align_of::<usize>());
+
+const THUNK_EXTRA_SIZE: usize = size_of::<usize>() * 2; // closure addr, return addr
 
 // We have to expose the thunk asm macros to allow the hrtb_cc proc macro to generate more complex
 // thunk templates
@@ -29,13 +55,13 @@ macro_rules! _thunk_asm {
     ($closure_ptr:ident) => {
         ::core::arch::asm!(
             "mov {cl_addr}, [rip + 2f]",
-            "jmp [rip + 3f]",
-            ".align 8",
+            "jmp [rip + 2f+$8]",
+            ".balign 8, 0xCC",
             "2:",
-            ".8byte {cl_magic}",
-            "3:",
-            ".8byte 0",
-            cl_magic = const { $crate::arch::CLOSURE_ADDR_MAGIC },
+            ".8byte {cl_magic_0}",
+            ".8byte {cl_magic_1}",
+            cl_magic_0 = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC[0] },
+            cl_magic_1 = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC[1] },
             cl_addr = out(reg) $closure_ptr,
             options(nostack)
         );
@@ -49,13 +75,15 @@ macro_rules! _thunk_asm {
 macro_rules! _thunk_asm {
     ($closure_ptr:ident) => {
         ::core::arch::asm!(
-            ".align 4",
-            "nopl 0(%eax)",
-            "mov ${cl_magic}, {cl_addr}",
-            "mov $1f, {jmp_addr}",
+            "mov $1f, {cl_addr}",
+            "mov $1f+$4, {jmp_addr}",
             "jmp *{jmp_addr}",
+            ".balign 8, 0xCC",
             "1:",
-            cl_magic = const { $crate::arch::CLOSURE_ADDR_MAGIC },
+            ".8byte cl_magic_0",
+            ".8byte cl_magic_1",
+            cl_magic_0 = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC[0] },
+            cl_magic_1 = const { $crate::arch::magic::CLOSURE_ADDR_MAGIC[1] },
             cl_addr = out(reg) $closure_ptr,
             jmp_addr = out(reg) _,
             options(nostack, att_syntax)
@@ -73,7 +101,7 @@ macro_rules! _thunk_asm {
             "ldr {cl_addr}, 1f",
             "ldr {jmp_addr}, 2f",
             "br {jmp_addr}",
-            ".align 3",
+            ".balign 8",
             "1:",
             ".8byte {cl_magic}",
             "2:",
@@ -96,7 +124,7 @@ macro_rules! _thunk_asm {
             "ldr {cl_addr}, 1f",
             "ldr {jmp_addr}, 2f",
             "bx {jmp_addr}",
-            ".align 2",
+            ".balign 4",
             "1:",
             ".4byte {cl_magic}",
             "2:",
@@ -150,7 +178,7 @@ pub(crate) unsafe fn create_thunk<J: JitAlloc>(
     closure_ptr: *const (),
     jit: &J,
 ) -> Result<ThunkInfo, JitAllocError> {
-    const PTR_SIZE: usize = size_of::<usize>();
+    const MAGIC_ALIGN: usize = align_of::<magic::Type>();
 
     // When in thumb mode, the thunk pointer will have the lower bit set to 1. Clear it
     #[cfg(thumb_mode)]
@@ -158,15 +186,15 @@ pub(crate) unsafe fn create_thunk<J: JitAlloc>(
 
     // Align to pointer size and search for the magic number to be replaced by the
     // closure address
-    let mut offset = thunk_template.align_offset(PTR_SIZE);
-    while thunk_template.add(offset).cast::<usize>().read() != CLOSURE_ADDR_MAGIC {
-        offset += PTR_SIZE;
+    let mut offset = thunk_template.align_offset(MAGIC_ALIGN);
+    while thunk_template.add(offset).cast::<magic::Type>().read() != magic::CLOSURE_ADDR_MAGIC {
+        offset += MAGIC_ALIGN;
     }
     let thunk_size = offset + THUNK_EXTRA_SIZE;
 
     // Skip initial bytes for proper alignment
-    let (rx, rw) = jit.alloc(thunk_size + PTR_SIZE - 1)?;
-    let align_offset = rw.add(offset).align_offset(PTR_SIZE);
+    let (rx, rw) = jit.alloc(thunk_size + MAGIC_ALIGN - 1)?;
+    let align_offset = rw.add(offset).align_offset(MAGIC_ALIGN);
     let (thunk_rx, rw) = (rx.add(align_offset), rw.add(align_offset));
 
     jit.protect_jit_memory(thunk_rx, thunk_size, ProtectJitAccess::ReadWrite);
@@ -177,16 +205,12 @@ pub(crate) unsafe fn create_thunk<J: JitAlloc>(
     // Write the closure pointer
     rw.add(offset).cast::<*const ()>().write(closure_ptr);
 
-    // On X86, we use a PE/ELF relocation for this
-    #[cfg(not(target_arch = "x86"))]
-    {
-        // Write the jump back to the compiler-generated thunk
-        let thunk_return = thunk_template.add(thunk_size);
-        // When in thumb mode, set the lower bit to one so we don't switch to A32 mode
-        #[cfg(thumb_mode)]
-        let thunk_return = thunk_return.map_addr(|a| a | 1);
-        rw.add(offset + PTR_SIZE).cast::<*const u8>().write(thunk_return);
-    }
+    // Write the jump back to the compiler-generated thunk
+    let thunk_return = thunk_template.add(thunk_size);
+    // When in thumb mode, set the lower bit to one so we don't switch to A32 mode
+    #[cfg(thumb_mode)]
+    let thunk_return = thunk_return.map_addr(|a| a | 1);
+    rw.add(offset + size_of::<usize>()).cast::<*const u8>().write(thunk_return);
 
     jit.protect_jit_memory(thunk_rx, thunk_size, ProtectJitAccess::ReadExecute);
     jit.flush_instruction_cache(thunk_rx, thunk_size);

--- a/src/bare_closure.rs
+++ b/src/bare_closure.rs
@@ -1,7 +1,53 @@
 //! Provides the [`BareFnOnce`], [`BareFnMut`] and [`BareFn`] wrapper types which allow closures to
 //! be called through context-free unsafe bare functions.
+//!
+//! Variants which erase the signature of the bare function (e.g. [`UntypedBareFn`]) are also
+//! provided. This can be useful when a type needs to own wrappers for functions of different
+//! signatures.
+//!
+//! # Thread Safety
+//!
+//! The closure wrapper types provided by this module are (trivially) [`Send`] if and only if both
+//! the closure's type-erased storage and the executable memory allocator used are.
+//!
+//! Canonically, they should also always be [`Sync`], as the invariants required for soundly
+//! calling the wrapped closure across threads are encoded in the `unsafe`ness of the
+//! bare function pointer returned by [`BareFnOnce::leak`], [`BareFnMut::bare`] and
+//! [`BareFn::bare`], and documented on these (safe) functions.
+//!
+//! However, such a [`Sync`] impl makes it very easy to call the bare function in situations where
+//! it is not allowed:
+//!
+//! ```compile_fail
+//! #[cfg(all(feature = "bundled_jit_alloc", not(feature = "no_std")))]
+//! {
+//!     use closure_ffi::{BareFn, Cell};
+//!     use std::{cell::Cell, thread};
+//!
+//!     let cell = Cell::new(0);
+//!
+//!     // WARNING: `wrapped` is Sync, but not the closure!
+//!     let wrapped = BareFn::new_c(move || -> u32 {
+//!         cell.set(cell.get() + 1)
+//!     });
+//!
+//!     // `wrapped` can be borrowed here at is it Sync. But by `bare()` documentation,
+//!     // calling the function is unsound as the closure is not Sync!
+//!     thread::scope(|s| {
+//!         s.spawn(|| unsafe { wrapped.bare()() });
+//!         s.spawn(|| unsafe { wrapped.bare()() }).join().unwrap()
+//!     })
+//! }
+//! ```
+//!
+//! To help guard against this, [`Sync`] is only implemented:
+//! - for [`BareFnOnceAny`]: When the closure is [`Send`]. The user is still responsible for
+//!   guarding against repeated calls.
+//! - for [`BareFnMutAny`]: When the closure is [`Send`]. The user is still responsible for guarding
+//!   against unsynchronized calls.
+//! - for [`BareFnAny`]: When the closure is [`Sync`].
 
-use core::{marker::PhantomData, mem::ManuallyDrop};
+use core::marker::PhantomData;
 
 #[cfg(feature = "proc_macros")]
 #[doc(hidden)]
@@ -153,8 +199,11 @@ macro_rules! cc_shorthand_in {
 macro_rules! bare_closure_impl {
     (
         ty_name: $ty_name:ident,
+        erased_ty_name: $erased_ty_name:ident,
         non_send_alias: $non_send_alias:ident,
         send_alias: $send_alias:ident,
+        sync_bounds: ($($sync_bounds: path),*),
+        send_alias_bound: $send_alias_bound: ty,
         trait_ident: $trait_ident:ident,
         thunk_template: $thunk_template:ident,
         bare_toggle: $bare_toggle:meta,
@@ -168,6 +217,123 @@ macro_rules! bare_closure_impl {
         send_alias_doc: $send_alias_doc:literal,
         safety_doc: $safety_doc:literal
     ) => {
+        #[cfg(any(feature = "bundled_jit_alloc", feature = "custom_jit_alloc"))]
+        #[cfg_attr(docsrs, doc(cfg(all())))]
+        /// Type-erased wrapper around a
+        #[doc = $fn_trait_doc]
+        /// closure which exposes a pointer to a bare function thunk.
+        ///
+        /// This type cannot be directly constructed; it must be produced from a
+        #[doc = $ty_name_doc]
+        /// through the `untyped` method or the [`Into`] trait.
+        ///
+        /// # Type parameters
+        /// - `S`: The dynamically-sized type to use to type-erase the closure. Use this to enforce
+        ///   lifetime bounds and marker traits which the closure must satsify, e.g. `S = dyn Send +
+        ///   'a`. Without the `unstable` feature, this is limited to [`dyn Any`](Any) and
+        ///   combinations of [`Send`] and [`Sync`] marker types.
+        /// - `A`: The [`JitAlloc`] implementation used to allocate and free executable memory.
+        ///
+        /// # Layout
+        #[doc = $ty_name_doc]
+        /// is `#[repr(transparent)]` with this type, so it is safe to transmute back and forth
+        /// provided the type parameters match.
+        #[allow(dead_code)]
+        pub struct $erased_ty_name<S: ?Sized, A: JitAlloc = GlobalJitAlloc> {
+            thunk_info: ThunkInfo,
+            jit_alloc: A,
+            // We can't directly own the closure, even through an UnsafeCell.
+            // Otherwise, holding a reference to a BareFnMut while the bare function is
+            // being called would be UB! So we reclaim the pointer in the Drop impl.
+            storage: *mut S,
+        }
+
+        // We copy the documentation to this type, since IDEs will often fetch it from here for
+        // pop-up documentation if neither feature is on
+        #[cfg(not(any(feature = "bundled_jit_alloc", feature = "custom_jit_alloc")))]
+        /// Type-erased wrapper around a
+        #[doc = $fn_trait_doc]
+        /// closure which exposes a pointer to a bare function thunk.
+        ///
+        /// This type cannot be directly constructed; it must be produced from a
+        #[doc = $ty_name_doc]
+        /// through the `untyped` method or the [`Into`] trait.
+        ///
+        /// # Type parameters
+        /// - `S`: The dynamically-sized type to use to type-erase the closure. Use this to enforce
+        ///   lifetime bounds and marker traits which the closure must satsify, e.g. `S = dyn Send +
+        ///   'a`. Without the `unstable` feature, this is limited to [`dyn Any`](Any) and
+        ///   combinations of [`Send`] and [`Sync`] marker types.
+        /// - `A`: The [`JitAlloc`] implementation used to allocate and free executable memory.
+        ///
+        /// # Layout
+        #[doc = $ty_name_doc]
+        /// is `#[repr(transparent)]` with this type, so it is safe to transmute back and forth
+        /// provided the type parameters match.
+        #[allow(dead_code)]
+        pub struct $erased_ty_name<S: ?Sized, A: JitAlloc> {
+            thunk_info: ThunkInfo,
+            jit_alloc: A,
+            storage: *mut S,
+        }
+
+        // SAFETY: S and A can be moved to other threads
+        unsafe impl<S: ?Sized + Send, A: JitAlloc + Send> Send for $erased_ty_name<S, A> {}
+        // SAFETY: See macro invocation
+        unsafe impl<S: $($sync_bounds+)* ?Sized, A: JitAlloc> Sync for $erased_ty_name<S, A> {}
+
+        impl<S: ?Sized, A: JitAlloc> $erased_ty_name<S, A> {
+            #[$bare_toggle]
+            /// Return a type-erased pointer to the bare function thunk wrapping the closure.
+            ///
+            /// # Safety
+            /// While this method is safe, using the returned pointer is very much not. In
+            /// particular, the only safe thing to do with it is casting it to the exact bare
+            /// function signature it had before erasure. Even then, it must not be called when:
+            /// - The lifetime of `self` has expired, or `self` has been dropped.
+            #[doc = $safety_doc]
+            #[inline]
+            pub fn bare(self: $bare_receiver) -> *const () {
+                self.thunk_info.thunk
+            }
+
+            /// Leak the underlying closure, returning the unsafe bare function pointer that invokes
+            /// it.
+            ///
+            /// `self` must be `'static` for this method to be called.
+            ///
+            /// # Safety
+            /// While this method is safe, using the returned pointer is very much not. In
+            /// particular, the only safe thing to do with it is casting it to the exact bare
+            /// function signature it had before erasure. Even then, it must not be called when:
+            #[doc = $safety_doc]
+            #[inline]
+            pub fn leak(self) -> *const ()
+            where
+                Self: 'static,
+            {
+                self.thunk_info.thunk
+            }
+        }
+
+        impl<S: ?Sized, A: JitAlloc> Drop for $erased_ty_name<S, A> {
+            fn drop(&mut self) {
+                // Don't panic on allocator failures for safety reasons
+                // SAFETY:
+                // - The caller of `bare()` promised not to call through the thunk after
+                // the lifetime of self expires
+                // - alloc_base is RX memory previously allocated by jit_alloc which has not been
+                // freed yet
+                unsafe { self.jit_alloc.release(self.thunk_info.alloc_base).ok() };
+
+                // Free the closure
+                // SAFETY:
+                // - The caller of `bare()` promised not to call through the thunk after
+                // the lifetime of self expires, so no borrow on closure exists
+                drop(unsafe { Box::from_raw(self.storage) })
+            }
+        }
+
         #[cfg(any(feature = "bundled_jit_alloc", feature = "custom_jit_alloc"))]
         #[cfg_attr(docsrs, doc(cfg(all())))]
         /// Wrapper around a
@@ -188,17 +354,15 @@ macro_rules! bare_closure_impl {
         /// - `B`: The bare function pointer to expose the closure as. For higher-kinded bare
         ///   function pointers, you will need to use the [`bare_hrtb`] macro to define a wrapper
         ///   type.
-        /// - `S`: The dynamically-sized type to use to type-erase the closure. By default, this is
-        ///   [`dyn Any`](Any) which is implemented by all `'static` types.
+        /// - `S`: The dynamically-sized type to use to type-erase the closure. Use this to enforce
+        ///   lifetime bounds and marker traits which the closure must satsify, e.g. `S = dyn Send +
+        ///   'a`. Without the `unstable` feature, this is limited to [`dyn Any`](Any) and
+        ///   combinations of [`Send`] and [`Sync`] marker types.
         /// - `A`: The [`JitAlloc`] implementation used to allocate and free executable memory.
         #[allow(dead_code)]
+        #[repr(transparent)]
         pub struct $ty_name<B: FnPtr, S: ?Sized, A: JitAlloc = GlobalJitAlloc> {
-            thunk_info: ThunkInfo,
-            jit_alloc: A,
-            // We can't directly own the closure, even through an UnsafeCell.
-            // Otherwise, holding a reference to a BareFnMut while the bare function is
-            // being called would be UB! So we reclaim the pointer in the Drop impl.
-            storage: *mut S,
+            untyped: $erased_ty_name<S, A>,
             phantom: PhantomData<B>,
         }
 
@@ -222,9 +386,10 @@ macro_rules! bare_closure_impl {
         /// - `B`: The bare function pointer to expose the closure as. For higher-kinded bare
         ///   function pointers, you will need to use the [`bare_hrtb`] macro to define a wrapper
         ///   type.
-        /// - `S`: The dynamically-sized type to use to type-erase the closure. Without the
-        ///   `unstable` feature, this is limited to [`dyn Any`](Any) and combinations of [`Send`]
-        ///   and [`Sync`] marker types.
+        /// - `S`: The dynamically-sized type to use to type-erase the closure. Use this to enforce
+        ///   lifetime bounds and marker traits which the closure must satsify, e.g. `S = dyn Send +
+        ///   'a`. Without the `unstable` feature, this is limited to [`dyn Any`](Any) and
+        ///   combinations of [`Send`] and [`Sync`] marker types.
         /// - `A`: The [`JitAlloc`] implementation used to allocate and free executable memory.
         #[allow(dead_code)]
         pub struct $ty_name<B: FnPtr, S: ?Sized, A: JitAlloc> {
@@ -234,12 +399,82 @@ macro_rules! bare_closure_impl {
             phantom: PhantomData<B>,
         }
 
-        // SAFETY: S and A can be moved to other threads
-        unsafe impl<B: FnPtr, S: ?Sized + Send, A: JitAlloc + Send> Send for $ty_name<B, S, A> {}
-        // SAFETY: The references to S and A cannot be accessed given a &Self
-        unsafe impl<B: FnPtr, S: ?Sized, A: JitAlloc> Sync for $ty_name<B, S, A> {}
+        // Split the impl blocks so that the relevant functions appear first in docs
+        #[cfg(any(feature = "bundled_jit_alloc", feature = "custom_jit_alloc"))]
+        impl<B: FnPtr, S: ?Sized> $ty_name<B, S, GlobalJitAlloc> {
+            /// Wraps `fun`, producing a bare function of signature `B`.
+            ///
+            /// This constructor is best used when the type of `B` is already known from an existing
+            /// type annotation. If you want to infer `B` from the closure arguments and a calling
+            /// convention, consider using
+            #[doc = $with_cc_doc]
+            /// or the `new_*` suffixed constructors instead.
+            ///
+            /// The W^X memory required is allocated using the global JIT allocator.
+            #[inline]
+            pub fn new<F>(fun: F) -> Self
+            where
+                F: ToBoxedUnsize<S>,
+                (B::CC, F): $trait_ident<B>,
+            {
+                Self::new_in(fun, Default::default())
+            }
+
+            /// Wraps `fun`, producing a bare function with calling convention `cconv`.
+            ///
+            /// The W^X memory required is allocated using the global JIT allocator.
+            #[inline]
+            pub fn with_cc<CC, F>(cconv: CC, fun: F) -> Self
+            where
+                F: ToBoxedUnsize<S>,
+                (CC, F): $trait_ident<B>,
+            {
+                Self::with_cc_in(cconv, fun, Default::default())
+            }
+        }
 
         impl<B: FnPtr, S: ?Sized, A: JitAlloc> $ty_name<B, S, A> {
+            #[$bare_toggle]
+            /// Return a bare function pointer that invokes the underlying closure.
+            ///
+            /// # Safety
+            /// While this method is safe, the returned function pointer is not. In particular, it
+            /// must not be called when:
+            /// - The lifetime of `self` has expired, or `self` has been dropped.
+            #[doc = $safety_doc]
+            #[inline]
+            pub fn bare(self: $bare_receiver) -> B {
+                // SAFETY: B is a bare function pointer
+                unsafe { B::from_ptr(self.untyped.bare()) }
+            }
+
+            /// Leak the underlying closure, returning the unsafe bare function pointer that invokes
+            /// it.
+            ///
+            /// `self` must be `'static` for this method to be called.
+            ///
+            /// # Safety
+            /// While this method is safe, the returned function pointer is not. In particular, it
+            /// must not be called when:
+            #[doc = $safety_doc]
+            #[inline]
+            pub fn leak(self) -> B
+            where
+                Self: 'static,
+            {
+                // SAFETY: B is a bare function pointer
+                unsafe { B::from_ptr(self.untyped.leak()) }
+            }
+
+            /// Erase the signature type from this
+            #[doc = $ty_name_doc]
+            ///
+            /// The returned value also exposes the [`Self::bare`] and [`Self::leak`] functions.
+            /// However, they now return untyped pointers.
+            pub fn into_untyped(self) -> $erased_ty_name<S, A> {
+                self.untyped
+            }
+
             /// Wraps `fun`, producing a bare function with calling convention `cconv`.
             ///
             /// Uses the provided JIT allocator to allocate the W^X memory used to create the thunk.
@@ -262,9 +497,11 @@ macro_rules! bare_closure_impl {
                     create_thunk(<(CC, F)>::$thunk_template, storage as *const _, &jit_alloc)?
                 };
                 Ok(Self {
-                    thunk_info,
-                    jit_alloc,
-                    storage,
+                    untyped: $erased_ty_name {
+                        thunk_info,
+                        jit_alloc,
+                        storage,
+                    },
                     phantom: PhantomData,
                 })
             }
@@ -309,159 +546,10 @@ macro_rules! bare_closure_impl {
             {
                 Self::with_cc_in(B::CC::default(), fun, jit_alloc)
             }
-
-            cc_shorthand_in!(new_c_in, $trait_ident, cc::C, "C");
-
-            cc_shorthand_in!(new_system_in, $trait_ident, cc::System, "system");
-
-            cc_shorthand_in!(
-                new_sysv64_in,
-                $trait_ident,
-                cc::Sysv64,
-                "sysv64",
-                all(not(windows), target_arch = "x86_64")
-            );
-
-            cc_shorthand_in!(
-                new_aapcs_in,
-                $trait_ident,
-                cc::Aapcs,
-                "aapcs",
-                any(doc, target_arch = "arm")
-            );
-
-            cc_shorthand_in!(
-                new_fastcall_in,
-                $trait_ident,
-                cc::Fastcall,
-                "fastcall",
-                all(windows, any(target_arch = "x86_64", target_arch = "x86"))
-            );
-
-            cc_shorthand_in!(
-                new_stdcall_in,
-                $trait_ident,
-                cc::Stdcall,
-                "stdcall",
-                all(windows, any(target_arch = "x86_64", target_arch = "x86"))
-            );
-
-            cc_shorthand_in!(
-                new_cdecl_in,
-                $trait_ident,
-                cc::Cdecl,
-                "cdecl",
-                all(windows, any(target_arch = "x86_64", target_arch = "x86"))
-            );
-
-            cc_shorthand_in!(
-                new_thiscall_in,
-                $trait_ident,
-                cc::Thiscall,
-                "thiscall",
-                all(windows, target_arch = "x86")
-            );
-
-            cc_shorthand_in!(
-                new_win64_in,
-                $trait_ident,
-                cc::Win64,
-                "win64",
-                all(windows, target_arch = "x86_64")
-            );
-
-            cc_shorthand_in!(
-                new_variadic_in,
-                $trait_ident,
-                cc::Variadic,
-                "`C` variadic",
-                feature = "c_variadic"
-            );
-
-            #[$bare_toggle]
-            /// Return a bare function pointer that invokes the underlying closure.
-            ///
-            /// # Safety
-            /// While this method is safe, the returned function pointer is not. In particular, it
-            /// must not be called when:
-            /// - The lifetime of `self` has expired, or `self` has been dropped.
-            #[doc = $safety_doc]
-            #[inline]
-            pub fn bare(self: $bare_receiver) -> B {
-                // SAFETY: B is a bare function pointer
-                unsafe { B::from_ptr(self.thunk_info.thunk) }
-            }
-
-            /// Leak the underlying closure, returning the unsafe bare function pointer that invokes
-            /// it.
-            ///
-            /// `self` must be `'static` for this method to be called.
-            ///
-            /// # Safety
-            /// While this method is safe, the returned function pointer is not. In particular, it
-            /// must not be called when:
-            #[doc = $safety_doc]
-            #[inline]
-            pub fn leak(self) -> B
-            where
-                Self: 'static,
-            {
-                let no_drop = ManuallyDrop::new(self);
-                // SAFETY: B is a bare function pointer
-                unsafe { B::from_ptr(no_drop.thunk_info.thunk) }
-            }
-        }
-
-        impl<B: FnPtr, S: ?Sized, A: JitAlloc> Drop for $ty_name<B, S, A> {
-            fn drop(&mut self) {
-                // Don't panic on allocator failures for safety reasons
-                // SAFETY:
-                // - The caller of `bare()` promised not to call through the thunk after
-                // the lifetime of self expires
-                // - alloc_base is RX memory previously allocated by jit_alloc which has not been
-                // freed yet
-                unsafe { self.jit_alloc.release(self.thunk_info.alloc_base).ok() };
-
-                // Free the closure
-                // SAFETY:
-                // - The caller of `bare()` promised not to call through the thunk after
-                // the lifetime of self expires, so no borrow on closure exists
-                drop(unsafe { Box::from_raw(self.storage) })
-            }
         }
 
         #[cfg(any(feature = "bundled_jit_alloc", feature = "custom_jit_alloc"))]
         impl<B: FnPtr, S: ?Sized> $ty_name<B, S, GlobalJitAlloc> {
-            /// Wraps `fun`, producing a bare function of signature `B`.
-            ///
-            /// This constructor is best used when the type of `B` is already known from an existing
-            /// type annotation. If you want to infer `B` from the closure arguments and a calling
-            /// convention, consider using
-            #[doc = $with_cc_doc]
-            /// or the `new_*` suffixed constructors instead.
-            ///
-            /// The W^X memory required is allocated using the global JIT allocator.
-            #[inline]
-            pub fn new<F>(fun: F) -> Self
-            where
-                F: ToBoxedUnsize<S>,
-                (B::CC, F): $trait_ident<B>,
-            {
-                Self::new_in(fun, Default::default())
-            }
-
-            /// Wraps `fun`, producing a bare function with calling convention `cconv`.
-            ///
-            /// The W^X memory required is allocated using the global JIT allocator.
-            #[inline]
-            pub fn with_cc<CC, F>(cconv: CC, fun: F) -> Self
-            where
-                F: ToBoxedUnsize<S>,
-                (CC, F): $trait_ident<B>,
-            {
-                Self::with_cc_in(cconv, fun, Default::default())
-            }
-
             cc_shorthand!(new_c, $trait_ident, cc::C, "C");
 
             cc_shorthand!(new_system, $trait_ident, cc::System, "system");
@@ -531,6 +619,76 @@ macro_rules! bare_closure_impl {
             );
         }
 
+        impl<B: FnPtr, S: ?Sized, A: JitAlloc> $ty_name<B, S, A> {
+            cc_shorthand_in!(new_c_in, $trait_ident, cc::C, "C");
+
+            cc_shorthand_in!(new_system_in, $trait_ident, cc::System, "system");
+
+            cc_shorthand_in!(
+                new_sysv64_in,
+                $trait_ident,
+                cc::Sysv64,
+                "sysv64",
+                all(not(windows), target_arch = "x86_64")
+            );
+
+            cc_shorthand_in!(
+                new_aapcs_in,
+                $trait_ident,
+                cc::Aapcs,
+                "aapcs",
+                any(doc, target_arch = "arm")
+            );
+
+            cc_shorthand_in!(
+                new_fastcall_in,
+                $trait_ident,
+                cc::Fastcall,
+                "fastcall",
+                all(windows, any(target_arch = "x86_64", target_arch = "x86"))
+            );
+
+            cc_shorthand_in!(
+                new_stdcall_in,
+                $trait_ident,
+                cc::Stdcall,
+                "stdcall",
+                all(windows, any(target_arch = "x86_64", target_arch = "x86"))
+            );
+
+            cc_shorthand_in!(
+                new_cdecl_in,
+                $trait_ident,
+                cc::Cdecl,
+                "cdecl",
+                all(windows, any(target_arch = "x86_64", target_arch = "x86"))
+            );
+
+            cc_shorthand_in!(
+                new_thiscall_in,
+                $trait_ident,
+                cc::Thiscall,
+                "thiscall",
+                all(windows, target_arch = "x86")
+            );
+
+            cc_shorthand_in!(
+                new_win64_in,
+                $trait_ident,
+                cc::Win64,
+                "win64",
+                all(windows, target_arch = "x86_64")
+            );
+
+            cc_shorthand_in!(
+                new_variadic_in,
+                $trait_ident,
+                cc::Variadic,
+                "`C` variadic",
+                feature = "c_variadic"
+            );
+        }
+
         #[cfg(any(feature = "bundled_jit_alloc", feature = "custom_jit_alloc"))]
         #[cfg_attr(docsrs, doc(cfg(all())))]
         /// Wrapper around a
@@ -556,26 +714,36 @@ macro_rules! bare_closure_impl {
 
         #[cfg(any(feature = "bundled_jit_alloc", feature = "custom_jit_alloc"))]
         #[cfg_attr(docsrs, doc(cfg(all())))]
-        /// Wrapper around a `Send`
+        /// Wrapper around a
         #[doc = $fn_trait_doc]
         /// closure which exposes a bare function thunk that can invoke it without
         /// additional arguments.
         ///
+        /// Unlike
+        #[doc = $non_send_alias_doc]
+        /// this type enforces the correct combination of [`Send`] and [`Sync`] on the
+        /// closure so that it is safe to both store and call from other threads.
+        ///
         /// This is a type alias only. Additional details and methods are described on the
         #[doc = $ty_name_doc]
         /// type.
-        pub type $send_alias<'a, B, A = GlobalJitAlloc> = $ty_name<B, dyn Send + 'a, A>;
+        pub type $send_alias<'a, B, A = GlobalJitAlloc> = $ty_name<B, $send_alias_bound, A>;
 
         #[cfg(not(any(feature = "bundled_jit_alloc", feature = "custom_jit_alloc")))]
-        /// Wrapper around a `Send`
+        /// Wrapper around a
         #[doc = $fn_trait_doc]
         /// closure which exposes a bare function thunk that can invoke it without
         /// additional arguments.
         ///
+        /// Unlike
+        #[doc = $non_send_alias_doc]
+        /// this type enforces the correct combination of [`Send`] and [`Sync`] on the
+        /// closure so that it is safe to both store and call from other threads.
+        ///
         /// This is a type alias only. Additional details and methods are described on the
         #[doc = $ty_name_doc]
         /// type.
-        pub type $send_alias<'a, B, A> = $ty_name<B, dyn Send + 'a, A>;
+        pub type $send_alias<'a, B, A> = $ty_name<B, $send_alias_bound, A>;
     };
 }
 
@@ -589,8 +757,11 @@ macro_rules! bare_closure_impl {
 
 bare_closure_impl!(
     ty_name: BareFnOnceAny,
+    erased_ty_name: UntypedBareFnOnce,
     non_send_alias: BareFnOnce,
     send_alias: BareFnOnceSend,
+    sync_bounds: (Send), // FnOnce only needs to be Send
+    send_alias_bound: dyn Send + 'a,
     trait_ident: FnOnceThunk,
     thunk_template: THUNK_TEMPLATE_ONCE,
     bare_toggle: cfg(any()),
@@ -608,8 +779,11 @@ bare_closure_impl!(
 
 bare_closure_impl!(
     ty_name: BareFnMutAny,
+    erased_ty_name: UntypedBareFnMut,
     non_send_alias: BareFnMut,
     send_alias: BareFnMutSend,
+    sync_bounds: (Send), // For FnMut we only need Send to make synchronized calls safe
+    send_alias_bound: dyn Send + 'a,
     trait_ident: FnMutThunk,
     thunk_template: THUNK_TEMPLATE_MUT,
     bare_toggle: cfg(all()),
@@ -621,13 +795,17 @@ bare_closure_impl!(
     try_with_cc_in_doc: "[`try_with_cc_in`](BareFnMutAny::try_with_cc_in)",
     non_send_alias_doc:  "[`BareFnMut`]",
     send_alias_doc: "[`BareFnMutSend`]",
-    safety_doc: "- A borrow induced by a previous call is still active.\n
-- The closure is not `Sync`, if calling from a different thread than the current one."
+    safety_doc: "- The mutable borrow induced by a previous call is still active (e.g. through recursion)
+  or concurrent (has no happens-before relationship) with the current one.\n
+- The closure is not `Send`, if calling from a different thread than the current one."
 );
 bare_closure_impl!(
     ty_name: BareFnAny,
+    erased_ty_name: UntypedBareFn,
     non_send_alias: BareFn,
     send_alias: BareFnSend,
+    sync_bounds: (Sync),
+    send_alias_bound: dyn Send + Sync + 'a,
     trait_ident: FnThunk,
     thunk_template: THUNK_TEMPLATE,
     bare_toggle: cfg(all()),

--- a/src/bare_closure.rs
+++ b/src/bare_closure.rs
@@ -395,9 +395,7 @@ macro_rules! bare_closure_impl {
         /// - `A`: The [`JitAlloc`] implementation used to allocate and free executable memory.
         #[allow(dead_code)]
         pub struct $ty_name<B: FnPtr, S: ?Sized, A: JitAlloc> {
-            thunk_info: ThunkInfo,
-            jit_alloc: A,
-            storage: *mut S,
+            untyped: $erased_ty_name<S, A>,
             phantom: PhantomData<B>,
         }
 

--- a/src/bare_closure.rs
+++ b/src/bare_closure.rs
@@ -217,6 +217,7 @@ macro_rules! bare_closure_impl {
         try_with_cc_in_doc: $try_with_cc_in_doc:literal,
         non_sync_alias_doc: $non_sync_alias_doc:literal,
         sync_alias_doc: $sync_alias_doc:literal,
+        sync_alias_bound_doc: $sync_alias_bound_doc:literal,
         safety_doc: $safety_doc:literal
     ) => {
         #[cfg(any(feature = "bundled_jit_alloc", feature = "custom_jit_alloc"))]
@@ -359,7 +360,7 @@ macro_rules! bare_closure_impl {
         /// type aliases for the common cases of `S = dyn Any + 'a` (no thread safety constraints)
         /// and
         #[doc = $sync_alias_bound_doc]
-        /// (minimum required to safely store/call the closure from other threads.).
+        /// (minimum required to safely store/call the closure from other threads), respectively.
         ///
         /// # Type parameters
         /// - `B`: The bare function pointer to expose the closure as. For higher-kinded bare
@@ -388,10 +389,13 @@ macro_rules! bare_closure_impl {
         /// This is a generic implementation which allows customizing the closure's
         /// type erased storage, which allows enforcing trait bounds like `Send` and `Sync` when
         /// needed. However, this plays poorly with type inference. Consider using the
-        #[doc = $non_send_alias_doc]
+        #[doc = $non_sync_alias_doc]
         /// and
-        #[doc = $send_alias_doc]
-        /// type aliases for the common cases of `S = dyn Any + 'a` and `S = dyn Send + 'a`.
+        #[doc = $sync_alias_doc]
+        /// type aliases for the common cases of `S = dyn Any + 'a` (no thread safety constraints)
+        /// and
+        #[doc = $sync_alias_bound_doc]
+        /// (minimum required to safely store/call the closure from other threads), respectively.
         ///
         /// # Type parameters
         /// - `B`: The bare function pointer to expose the closure as. For higher-kinded bare
@@ -782,6 +786,7 @@ bare_closure_impl!(
     try_with_cc_in_doc: "[`try_with_cc_in`](BareFnOnceAny::try_with_cc_in)",
     non_sync_alias_doc: "[`BareFnOnce`]",
     sync_alias_doc: "[`BareFnOnceSend`]",
+    sync_alias_bound_doc: "[`dyn Send + 'a`](Send)",
     safety_doc: "- The function has been called before.\n
 - The closure is not `Send`, if calling from a different thread than the current one."
 );
@@ -804,6 +809,7 @@ bare_closure_impl!(
     try_with_cc_in_doc: "[`try_with_cc_in`](BareFnMutAny::try_with_cc_in)",
     non_sync_alias_doc:  "[`BareFnMut`]",
     sync_alias_doc: "[`BareFnMutSend`]",
+    sync_alias_bound_doc: "[`dyn Send + 'a`](Send)",
     safety_doc: "- The mutable borrow induced by a previous call is still active (e.g. through recursion)
   or concurrent (has no happens-before relationship) with the current one.\n
 - The closure is not `Send`, if calling from a different thread than the current one."
@@ -826,5 +832,6 @@ bare_closure_impl!(
     try_with_cc_in_doc: "[`try_with_cc_in`](BareFnAny::try_with_cc_in)",
     non_sync_alias_doc:  "[`BareFn`]",
     sync_alias_doc: "[`BareFnSend`]",
+    sync_alias_bound_doc: "[`dyn Send + Sync + 'a`](Sync)",
     safety_doc: "- The closure is not `Sync`, if calling from a different thread than the current one."
 );

--- a/src/bare_closure.rs
+++ b/src/bare_closure.rs
@@ -318,6 +318,12 @@ macro_rules! bare_closure_impl {
             }
         }
 
+        impl<B: FnPtr, S: ?Sized, A: JitAlloc> From<$ty_name<B, S, A>> for $erased_ty_name<S, A> {
+            fn from(value: $ty_name<B, S, A>) -> Self {
+                value.into_untyped()
+            }
+        }
+
         impl<S: ?Sized, A: JitAlloc> Drop for $erased_ty_name<S, A> {
             fn drop(&mut self) {
                 // Don't panic on allocator failures for safety reasons

--- a/src/bare_closure.rs
+++ b/src/bare_closure.rs
@@ -357,7 +357,7 @@ macro_rules! bare_closure_impl {
         #[doc = $non_sync_alias_doc]
         /// and
         #[doc = $sync_alias_doc]
-        /// type aliases for the common cases of `S = dyn Any + 'a` (no thread safety constraints)
+        /// type aliases for the common cases of [`S = dyn Any + 'a`](Any) (no thread safety constraints)
         /// and
         #[doc = $sync_alias_bound_doc]
         /// (minimum required to safely store/call the closure from other threads), respectively.
@@ -392,7 +392,7 @@ macro_rules! bare_closure_impl {
         #[doc = $non_sync_alias_doc]
         /// and
         #[doc = $sync_alias_doc]
-        /// type aliases for the common cases of `S = dyn Any + 'a` (no thread safety constraints)
+        /// type aliases for the common cases of [`S = dyn Any + 'a`](Any) (no thread safety constraints)
         /// and
         #[doc = $sync_alias_bound_doc]
         /// (minimum required to safely store/call the closure from other threads), respectively.
@@ -786,7 +786,7 @@ bare_closure_impl!(
     try_with_cc_in_doc: "[`try_with_cc_in`](BareFnOnceAny::try_with_cc_in)",
     non_sync_alias_doc: "[`BareFnOnce`]",
     sync_alias_doc: "[`BareFnOnceSend`]",
-    sync_alias_bound_doc: "[`dyn Send + 'a`](Send)",
+    sync_alias_bound_doc: "[`S = dyn Send + 'a`](Send)",
     safety_doc: "- The function has been called before.\n
 - The closure is not `Send`, if calling from a different thread than the current one."
 );
@@ -809,7 +809,7 @@ bare_closure_impl!(
     try_with_cc_in_doc: "[`try_with_cc_in`](BareFnMutAny::try_with_cc_in)",
     non_sync_alias_doc:  "[`BareFnMut`]",
     sync_alias_doc: "[`BareFnMutSend`]",
-    sync_alias_bound_doc: "[`dyn Send + 'a`](Send)",
+    sync_alias_bound_doc: "[`S = dyn Send + 'a`](Send)",
     safety_doc: "- The mutable borrow induced by a previous call is still active (e.g. through recursion)
   or concurrent (has no happens-before relationship) with the current one.\n
 - The closure is not `Send`, if calling from a different thread than the current one."
@@ -832,6 +832,6 @@ bare_closure_impl!(
     try_with_cc_in_doc: "[`try_with_cc_in`](BareFnAny::try_with_cc_in)",
     non_sync_alias_doc:  "[`BareFn`]",
     sync_alias_doc: "[`BareFnSend`]",
-    sync_alias_bound_doc: "[`dyn Send + Sync + 'a`](Sync)",
+    sync_alias_bound_doc: "[`S = dyn Send + Sync + 'a`](Sync)",
     safety_doc: "- The closure is not `Sync`, if calling from a different thread than the current one."
 );

--- a/src/bare_closure.rs
+++ b/src/bare_closure.rs
@@ -227,7 +227,7 @@ macro_rules! bare_closure_impl {
         ///
         /// This type cannot be directly constructed; it must be produced from a
         #[doc = $ty_name_doc]
-        /// through the `untyped` method or the [`Into`] trait.
+        /// through the `into_untyped` method or the [`Into`] trait.
         ///
         /// # Type parameters
         /// - `S`: The dynamically-sized type to use to type-erase the closure. Use this to enforce
@@ -259,7 +259,7 @@ macro_rules! bare_closure_impl {
         ///
         /// This type cannot be directly constructed; it must be produced from a
         #[doc = $ty_name_doc]
-        /// through the `untyped` method or the [`Into`] trait.
+        /// through the `into_untyped` method or the [`Into`] trait.
         ///
         /// # Type parameters
         /// - `S`: The dynamically-sized type to use to type-erase the closure. Use this to enforce

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,8 @@ pub mod traits;
 pub mod prelude {
     #[doc(inline)]
     pub use super::bare_closure::{
-        BareFn, BareFnAny, BareFnMut, BareFnMutAny, BareFnMutSend, BareFnOnce, BareFnOnceAny,
-        BareFnOnceSend, BareFnSend,
+        BareFn, BareFnAny, BareFnMut, BareFnMutAny, BareFnMutSync, BareFnOnce, BareFnOnceAny,
+        BareFnOnceSync, BareFnSync,
     };
     #[doc(inline)]
     pub use super::cc;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(feature = "no_std", no_std)]
 #![cfg_attr(feature = "unstable", feature(unsize))]
+#![cfg_attr(feature = "unstable", feature(ptr_metadata))]
 #![cfg_attr(feature = "tuple_trait", feature(tuple_trait))]
 #![cfg_attr(feature = "c_variadic", feature(c_variadic))]
 #![doc = include_str!("../README.md")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub mod prelude {
     #[doc(inline)]
     pub use super::bare_closure::{
         BareFn, BareFnAny, BareFnMut, BareFnMutAny, BareFnMutSync, BareFnOnce, BareFnOnceAny,
-        BareFnOnceSync, BareFnSync,
+        BareFnOnceSync, BareFnSync, UntypedBareFn, UntypedBareFnMut, UntypedBareFnOnce,
     };
     #[doc(inline)]
     pub use super::cc;

--- a/tests/test_explicit_alloc.rs
+++ b/tests/test_explicit_alloc.rs
@@ -249,7 +249,7 @@ fn test_untyped_upcast() {
     let send_and_sync = BareFnSync::new_c_in(
         move || {
             let drop_flag = &check;
-            drop_flag.0.load(SeqCst);
+            drop_flag.0.load(SeqCst)
         },
         &SLAB,
     );

--- a/tests/test_explicit_alloc.rs
+++ b/tests/test_explicit_alloc.rs
@@ -167,10 +167,9 @@ fn test_unwind_fn() {
     assert!(result.is_err())
 }
 
+#[cfg(not(feature = "no_std"))]
 #[test]
 fn test_untyped_bare_fn() {
-    #[cfg(feature = "no_std")]
-    use alloc::vec::Vec;
     use core::cell::Cell;
 
     // Use this type to verify that our closures were dropped


### PR DESCRIPTION
# Breaking Changes
- [x] Adjust send/sync impl for `BareFn` and friends so that Sync is only implemented when the closure has the right Send/Sync bounds to make it sound to call it from another thread, modulo the other safety requirements for calling it.

# Added
- [x] Add untyped variants of `BareFn` structs, making it possible to hold many at once

# Changes
- [x] Change thunk assembly magic numbers/sentinel values to sequences that are guaranteed to not be emitted by the compiler. Thanks to @Dasaav-dsv for the help.