### PR TITLE
Feat: thunk factory and wrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v3.0.1] - 2025-06-21
 
 ### Fixed
+- `libc` dependency not compatible with `no_std` on Linux ARM targets
+
+## [v3.0.1] - 2025-06-21
+
+### Fixed
 - docs.rs build
 
 ## [v3.0.0] - 2025-06-20

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ jit-allocator2 = {version = "0.2.9", optional = true }
 spin = { version = "0.10", optional = true }
 
 [target.'cfg(all(target_arch = "arm", target_os = "linux"))'.dependencies]
-libc = "0.2"
+libc = { version = "0.2", default-features = false }
 
 [build-dependencies]
 rustflags = "0.1.7"

--- a/src/bare_closure.rs
+++ b/src/bare_closure.rs
@@ -499,6 +499,12 @@ macro_rules! bare_closure_impl {
                 Self::with_cc_in(cconv, fun, Default::default())
             }
 
+            /// Create a
+            #[doc = $ty_name_doc]
+            /// directly from a
+            #[doc = concat!("[`", stringify!($trait_ident), "`].")]
+            ///
+            /// The W^X memory required is allocated using the global JIT allocator.
             pub fn with_thunk<T>(thunk: T) -> Self where T: $trait_ident<B> + ToBoxedDyn<S>
             {
                 Self::with_thunk_in(thunk, Default::default())
@@ -635,6 +641,12 @@ macro_rules! bare_closure_impl {
                 Self::with_cc_in(B::CC::default(), fun, jit_alloc)
             }
 
+            /// Create a
+            #[doc = $ty_name_doc]
+            /// directly from a
+            #[doc = concat!("[`", stringify!($trait_ident), "`].")]
+            ///
+            /// Uses `jit_alloc` to allocate the W^X memory used to create the thunk.
             pub fn try_with_thunk_in<T>(thunk: T, jit_alloc: A) -> Result<Self, JitAllocError>
             where T: $trait_ident<B> + ToBoxedDyn<S>
             {
@@ -657,6 +669,16 @@ macro_rules! bare_closure_impl {
                 })
             }
 
+            /// Create a
+            #[doc = $ty_name_doc]
+            /// directly from a
+            #[doc = concat!("[`", stringify!($trait_ident), "`].")]
+            ///
+            /// Uses `jit_alloc` to allocate the W^X memory used to create the thunk.
+            ///
+            /// # Panics
+            /// If the provided JIT allocator fails to allocate memory. For a non-panicking
+            /// version, see [`Self::try_with_thunk_in`].
             #[inline]
             pub fn with_thunk_in<T>(thunk: T, jit_alloc: A) -> Self
             where T: $trait_ident<B> + ToBoxedDyn<S>

--- a/src/cc.rs
+++ b/src/cc.rs
@@ -32,6 +32,7 @@ macro_rules! cc_thunk_impl_triple {
                 self as *const _
             }
 
+            #[inline(always)]
             fn make_once_thunk<F>(fun: F) -> impl $crate::traits::FnOnceThunk<Self>
             where
                 F: for<'a, 'b, 'c> $crate::traits::PackedFnOnce<'a, 'b, 'c, Self>
@@ -39,6 +40,7 @@ macro_rules! cc_thunk_impl_triple {
                 (Self::CC::default(), move |$($args,)*| fun(($($args,)*)))
             }
 
+            #[inline(always)]
             fn make_mut_thunk<F>(mut fun: F) -> impl $crate::traits::FnMutThunk<Self>
             where
                 F: for<'a, 'b, 'c> $crate::traits::PackedFnMut<'a, 'b, 'c, Self>
@@ -46,6 +48,7 @@ macro_rules! cc_thunk_impl_triple {
                 (Self::CC::default(), move |$($args,)*| fun(($($args,)*)))
             }
 
+            #[inline(always)]
             fn make_thunk<F>(fun: F) -> impl $crate::traits::FnThunk<Self>
             where
                 F: for<'a, 'b, 'c> $crate::traits::PackedFn<'a, 'b, 'c, Self>
@@ -301,11 +304,13 @@ macro_rules! cc_thunk_impl_triple_variadic {
                 self as *const _
             }
 
+            #[inline(always)]
             fn make_once_thunk<F>(fun: F) -> impl $crate::traits::FnOnceThunk<Self>
             where
                 F: for<'a, 'b, 'c> $crate::traits::PackedFnOnce<'a, 'b, 'c, Self>
             {
                 // needed to create a HRTB closure
+                #[inline(always)]
                 fn coerce<R, $($id_tys,)* F>(fun: F) -> F
                 where F: for<'va> FnOnce($($tys,)* core::ffi::VaListImpl<'va>) -> R {
                     fun
@@ -314,10 +319,12 @@ macro_rules! cc_thunk_impl_triple_variadic {
                 (Self::CC::default(), coerced)
             }
 
+            #[inline(always)]
             fn make_mut_thunk<F>(mut fun: F) -> impl $crate::traits::FnMutThunk<Self>
             where
                 F: for<'a, 'b, 'c> $crate::traits::PackedFnMut<'a, 'b, 'c, Self>
             {
+                #[inline(always)]
                 fn coerce<R, $($id_tys,)* F>(fun: F) -> F
                 where F: for<'va> FnMut($($tys,)* core::ffi::VaListImpl<'va>) -> R {
                     fun
@@ -326,10 +333,12 @@ macro_rules! cc_thunk_impl_triple_variadic {
                 (Self::CC::default(), coerced)
             }
 
+            #[inline(always)]
             fn make_thunk<F>(fun: F) -> impl $crate::traits::FnThunk<Self>
             where
                 F: for<'a, 'b, 'c> $crate::traits::PackedFn<'a, 'b, 'c, Self>
             {
+                #[inline(always)]
                 fn coerce<R, $($id_tys,)* F>(fun: F) -> F
                 where F: for<'va> Fn($($tys,)* core::ffi::VaListImpl<'va>) -> R {
                     fun

--- a/src/cc.rs
+++ b/src/cc.rs
@@ -291,7 +291,9 @@ macro_rules! cc_thunk_impl_triple_variadic {
             #[inline(always)]
             unsafe fn call<'a, 'b, 'c>(self, args: Self::Args<'a, 'b, 'c>) -> Self::Ret<'a, 'b, 'c>
             {
-                panic!("FnPtr::call is not supported on C variadics due to a language limitations")
+                const {
+                    panic!("FnPtr::call is not supported on C variadics due to a language limitations")
+                }
             }
 
             #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod arch;
 pub mod bare_closure;
 pub mod cc;
 pub mod jit_alloc;
+pub mod thunk_factory;
 pub mod traits;
 
 /// Common imports required to use `closure-ffi`.

--- a/src/thunk_factory.rs
+++ b/src/thunk_factory.rs
@@ -1,0 +1,175 @@
+//! Provides factory functions for creating [`FnThunk`] implementations from a closure while
+//! preserving its [Sync]/[Send]ness.
+
+use crate::traits::{FnMutThunk, FnOnceThunk, FnPtr, FnThunk, PackedFn, PackedFnMut, PackedFnOnce};
+
+// SAFETY: Using the `SendSyncWrapper` type below is only unsound if `FnPtr::make_thunk` and friends
+// do not preserve the send/syncness of `fun` in the generated thunks. Since the opaque thunk impl
+// is merely the combination of a ZST calling convention marker type and the same closure with
+// expanded parameters, the marker traits are preserved.
+
+/// Creates a [`FnOnceThunk`] implementation from a closure taking the same arguments as this
+/// function pointer.
+///
+/// This is identical to [`FnPtr::make_once_thunk`] and is only provided for convenience.
+#[inline(always)]
+pub fn make_once<B: FnPtr, F>(fun: F) -> impl FnOnceThunk<B>
+where
+    F: Send + for<'x, 'y, 'z> PackedFnOnce<'x, 'y, 'z, B>,
+{
+    B::make_once_thunk(fun)
+}
+
+/// Creates a [Send] [`FnOnceThunk`] implementation from a closure taking the same arguments as
+/// this function pointer.
+#[inline(always)]
+pub fn make_once_send<B: FnPtr, F>(fun: F) -> impl FnOnceThunk<B> + Send
+where
+    F: Send + for<'x, 'y, 'z> PackedFnOnce<'x, 'y, 'z, B>,
+{
+    let thunk = B::make_once_thunk(fun);
+    SendSyncWrapper(thunk)
+}
+
+/// Creates a [Sync] [`FnOnceThunk`] implementation from a closure taking the same arguments as
+/// this function pointer.
+#[inline(always)]
+pub fn make_once_sync<B: FnPtr, F>(fun: F) -> impl FnOnceThunk<B> + Sync
+where
+    F: Sync + for<'x, 'y, 'z> PackedFnOnce<'x, 'y, 'z, B>,
+{
+    let thunk = B::make_once_thunk(fun);
+    SendSyncWrapper(thunk)
+}
+
+/// Creates a [Send] and [Sync] [`FnOnceThunk`] implementation from a closure taking the same
+/// arguments as this function pointer.
+#[inline(always)]
+pub fn make_once_send_sync<B: FnPtr, F>(fun: F) -> impl FnOnceThunk<B> + Send + Sync
+where
+    F: Send + Sync + for<'x, 'y, 'z> PackedFnOnce<'x, 'y, 'z, B>,
+{
+    let thunk = B::make_once_thunk(fun);
+    SendSyncWrapper(thunk)
+}
+
+/// Creates a [`FnMutThunk`] implementation from a closure taking the same arguments as this
+/// function pointer.
+///
+/// This is identical to [`FnPtr::make_mut_thunk`] and is only provided for convenience.
+#[inline(always)]
+pub fn make_mut<B: FnPtr, F>(fun: F) -> impl FnMutThunk<B>
+where
+    F: for<'x, 'y, 'z> PackedFnMut<'x, 'y, 'z, B>,
+{
+    B::make_mut_thunk(fun)
+}
+
+/// Creates a [Send] [`FnMutThunk`] implementation from a closure taking the same arguments as
+/// this function pointer.
+#[inline(always)]
+pub fn make_mut_send<B: FnPtr, F>(fun: F) -> impl FnMutThunk<B> + Send
+where
+    F: Send + for<'x, 'y, 'z> PackedFnMut<'x, 'y, 'z, B>,
+{
+    let thunk = B::make_mut_thunk(fun);
+    SendSyncWrapper(thunk)
+}
+
+/// Creates a [Sync] [`FnMutThunk`] implementation from a closure taking the same arguments as
+/// this function pointer.
+#[inline(always)]
+pub fn make_mut_sync<B: FnPtr, F>(fun: F) -> impl FnMutThunk<B> + Sync
+where
+    F: Sync + for<'x, 'y, 'z> PackedFnMut<'x, 'y, 'z, B>,
+{
+    let thunk = B::make_mut_thunk(fun);
+    SendSyncWrapper(thunk)
+}
+
+/// Creates a [Send] and [Sync] [`FnMutThunk`] implementation from a closure taking the same
+/// arguments as this function pointer.
+#[inline(always)]
+pub fn make_mut_send_sync<B: FnPtr, F>(fun: F) -> impl FnMutThunk<B> + Send + Sync
+where
+    F: Send + Sync + for<'x, 'y, 'z> PackedFnMut<'x, 'y, 'z, B>,
+{
+    let thunk = B::make_mut_thunk(fun);
+    SendSyncWrapper(thunk)
+}
+
+/// Creates a [`FnThunk`] implementation from a closure taking the same arguments as this
+/// function pointer.
+///
+/// This is identical to [`FnPtr::make_thunk`] and is only provided for convenience.
+#[inline(always)]
+pub fn make<B: FnPtr, F>(fun: F) -> impl FnThunk<B>
+where
+    F: for<'x, 'y, 'z> PackedFn<'x, 'y, 'z, B>,
+{
+    B::make_thunk(fun)
+}
+/// Creates a [Send] [`FnThunk`] implementation from a closure taking the same arguments as
+/// this function pointer.
+#[inline(always)]
+pub fn make_send<B: FnPtr, F>(fun: F) -> impl FnThunk<B> + Send
+where
+    F: Send + for<'x, 'y, 'z> PackedFn<'x, 'y, 'z, B>,
+{
+    let thunk = B::make_thunk(fun);
+    SendSyncWrapper(thunk)
+}
+
+/// Creates a [Sync] [`FnThunk`] implementation from a closure taking the same arguments as
+/// this function pointer.
+#[inline(always)]
+pub fn make_sync<B: FnPtr, F>(fun: F) -> impl FnThunk<B> + Sync
+where
+    F: Sync + for<'x, 'y, 'z> PackedFn<'x, 'y, 'z, B>,
+{
+    let thunk = B::make_thunk(fun);
+    SendSyncWrapper(thunk)
+}
+
+/// Creates a [Send] and [Sync] [`FnThunk`] implementation from a closure taking the same
+/// arguments as this function pointer.
+#[inline(always)]
+pub fn make_send_sync<B: FnPtr, F>(fun: F) -> impl FnThunk<B> + Send + Sync
+where
+    F: Send + Sync + for<'x, 'y, 'z> PackedFn<'x, 'y, 'z, B>,
+{
+    let thunk = B::make_thunk(fun);
+    SendSyncWrapper(thunk)
+}
+
+#[repr(transparent)]
+struct SendSyncWrapper<T>(T);
+unsafe impl<T> Send for SendSyncWrapper<T> {}
+unsafe impl<T> Sync for SendSyncWrapper<T> {}
+unsafe impl<B: FnPtr, T: FnOnceThunk<B>> FnOnceThunk<B> for SendSyncWrapper<T> {
+    const THUNK_TEMPLATE_ONCE: *const u8 = T::THUNK_TEMPLATE_ONCE;
+    unsafe fn call_once<'a, 'b, 'c>(
+        self,
+        args: <B as FnPtr>::Args<'a, 'b, 'c>,
+    ) -> <B as FnPtr>::Ret<'a, 'b, 'c> {
+        self.0.call_once(args)
+    }
+}
+unsafe impl<B: FnPtr, T: FnMutThunk<B>> FnMutThunk<B> for SendSyncWrapper<T> {
+    const THUNK_TEMPLATE_MUT: *const u8 = T::THUNK_TEMPLATE_MUT;
+    unsafe fn call_mut<'a, 'b, 'c>(
+        &mut self,
+        args: <B as FnPtr>::Args<'a, 'b, 'c>,
+    ) -> <B as FnPtr>::Ret<'a, 'b, 'c> {
+        self.0.call_mut(args)
+    }
+}
+unsafe impl<B: FnPtr, T: FnThunk<B>> FnThunk<B> for SendSyncWrapper<T> {
+    const THUNK_TEMPLATE: *const u8 = T::THUNK_TEMPLATE;
+    unsafe fn call<'a, 'b, 'c>(
+        &self,
+        args: <B as FnPtr>::Args<'a, 'b, 'c>,
+    ) -> <B as FnPtr>::Ret<'a, 'b, 'c> {
+        self.0.call(args)
+    }
+}

--- a/tests/test_explicit_alloc.rs
+++ b/tests/test_explicit_alloc.rs
@@ -3,6 +3,7 @@
 
 mod slab_alloc;
 
+use closure_ffi::traits::{FnMutThunk, FnPtr, FnThunk};
 #[allow(unused_imports)]
 use closure_ffi::{cc, BareFn, BareFnMut, BareFnOnce, UntypedBareFn};
 use slab_alloc::SlabAlloc;
@@ -272,4 +273,41 @@ fn test_upcast() {
 
     drop(untyped_any);
     assert!(dropped.load(SeqCst));
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn test_wrap() {
+    fn lock_and_debug<B: FnPtr, F>(fun: F) -> impl FnThunk<B>
+    where
+        for<'a, 'b, 'c> B::Ret<'a, 'b, 'c>: core::fmt::Debug,
+        (cc::C, F): FnMutThunk<B>,
+    {
+        let locked = std::sync::Mutex::new((cc::C, fun));
+        B::make_thunk(move |args| unsafe {
+            let ret = locked.lock().unwrap().call_mut(args);
+            println!("value: {ret:?}");
+            ret
+        })
+    }
+
+    let mut counter = 0;
+    let locked_inc = BareFn::with_thunk_in(
+        lock_and_debug(|n: usize| {
+            counter += n;
+            counter
+        }),
+        &SLAB,
+    );
+    // Safety: see `lock_and_debug` impl.
+    let locked_inc = unsafe { locked_inc.downcast::<dyn Sync>() };
+
+    std::thread::scope(|s| {
+        for _ in 0..1000 {
+            s.spawn(|| unsafe { locked_inc.bare()(5) });
+        }
+    });
+
+    drop(locked_inc);
+    assert_eq!(counter, 5000);
 }

--- a/tests/test_macros.rs
+++ b/tests/test_macros.rs
@@ -65,9 +65,12 @@ fn test_non_static_hrtb() {
     assert_eq!(ref_str, &*owned_str2);
 }
 
-bare_hrtb! {
-    type MyGenericFn<T> where T: Clone = for<'a> extern "C" fn(&'a Option<T>) -> Option<&'a T>;
-}
+bare_hrtb!(
+    type MyGenericFn<T>
+    where
+        T: 'static + Clone,
+    = for<'a> extern "C" fn(&'a Option<T>) -> Option<&'a T>;
+);
 
 #[test]
 fn test_generic_hrtb() {


### PR DESCRIPTION
Adds `make_*_thunk` functions to `FnPtr`, `call` methods to `Fn*Thunk` and the `thunk_factory` module to make code like this possible: 

```rs
use closure_ffi::{thunk_factory,  BareFnSync, traits::{FnPtr, FnThunk, FnMutThunk}};

fn lock_and_debug<B: FnPtr, F: Send>(fun: F) -> impl FnThunk<B> + Sync
where
    for<'a, 'b, 'c> B::Ret<'a, 'b, 'c>: core::fmt::Debug,
    (cc::C, F): FnMutThunk<B>,
{
    let locked = std::sync::Mutex::new((cc::C, fun));
    thunk_factory::make_sync(move |args| unsafe {
        let ret = locked.lock().unwrap().call_mut(args);
        println!("value: {ret:?}");
        ret
    })
}

let mut counter = 0;
let locked_inc = BareFnSync::with_thunk_in(
    lock_and_debug(|n: usize| {
        counter += n;
        counter
    }),
    &SLAB,
);

std::thread::scope(|s| {
    for _ in 0..1000 {
        s.spawn(|| unsafe { locked_inc.bare()(5) });
    }
});

drop(locked_inc);
assert_eq!(counter, 5000);
 ```
A consequence of this is a few breaking changes as well as a regression on the expressivity of the `bare_hrtb!` macro (now requires `'static` bounds on generics in some situations).